### PR TITLE
fix:usr:Fix connection string for oracle

### DIFF
--- a/tests/test_dbexplorer.py
+++ b/tests/test_dbexplorer.py
@@ -414,6 +414,7 @@ class TestDispatcher(TestCase):
                                        port=None,
                                        output_format='ascii_table',
                                        connection_type='postgres',
+                                       database='public',
                                        scan_type=None,
                                        user='user',
                                        password='pass'))


### PR DESCRIPTION
Connection string for oracle had misplaced port.
Accept a database name. This is required for a few database types.
Default scan type is shallow.

