### PR TITLE
More fixes for oracle

### DIFF
--- a/piicatcher/db/metadata.py
+++ b/piicatcher/db/metadata.py
@@ -124,6 +124,7 @@ class Column(NamedObject):
         logging.debug(self._pii)
 
     def shallow_scan(self):
+        logging.debug("Scanning column name %s" % self._name)
         [self._pii.add(pii) for pii in self.column_scanner.scan(self._name)]
 
     def get_dict(self):

--- a/piicatcher/scanner.py
+++ b/piicatcher/scanner.py
@@ -65,17 +65,17 @@ class ColumnNameScanner(Scanner):
     regex = {
         PiiTypes.PERSON: re.compile("^.*(firstname|fname|lastname|lname|"
                                     "fullname|fname|maidenname|_name|"
-                                    "nickname|name_suffix|name).*$"),
-        PiiTypes.EMAIL: re.compile("^.*(email|e-mail|mail).*$"),
+                                    "nickname|name_suffix|name).*$", re.IGNORECASE),
+        PiiTypes.EMAIL: re.compile("^.*(email|e-mail|mail).*$", re.IGNORECASE),
         PiiTypes.BIRTH_DATE: re.compile("^.*(date_of_birth|dateofbirth|dob|"
-                                        "birthday|date_of_death|dateofdeath).*$"),
-        PiiTypes.GENDER: re.compile("^.*(gender).*$"),
-        PiiTypes.NATIONALITY: re.compile("^.*(nationality).*$"),
+                                        "birthday|date_of_death|dateofdeath).*$", re.IGNORECASE),
+        PiiTypes.GENDER: re.compile("^.*(gender).*$", re.IGNORECASE),
+        PiiTypes.NATIONALITY: re.compile("^.*(nationality).*$", re.IGNORECASE),
         PiiTypes.ADDRESS: re.compile("^.*(address|city|state|county|country|"
-                                     "zipcode|postal).*$"),
-        PiiTypes.USER_NAME: re.compile("^.*user(id|name|).*$"),
-        PiiTypes.PASSWORD: re.compile("^.*pass.*$"),
-        PiiTypes.SSN: re.compile("^.*(ssn|social).*$")
+                                     "zipcode|postal).*$", re.IGNORECASE),
+        PiiTypes.USER_NAME: re.compile("^.*user(id|name|).*$", re.IGNORECASE),
+        PiiTypes.PASSWORD: re.compile("^.*pass.*$", re.IGNORECASE),
+        PiiTypes.SSN: re.compile("^.*(ssn|social).*$", re.IGNORECASE)
     }
 
     def scan(self, text):

--- a/tests/test_dbexplorer.py
+++ b/tests/test_dbexplorer.py
@@ -34,9 +34,14 @@ class ExplorerTest(TestCase):
 
         self.explorer._schemas = [schema]
 
-    def test_tabular(self):
+    def test_tabular_all(self):
         self.assertEqual([
             ['testSchema', 't1', 'c1', False],
+            ['testSchema', 't1', 'c2', True]
+        ], self.explorer.get_tabular(True))
+
+    def test_tabular_pii(self):
+        self.assertEqual([
             ['testSchema', 't1', 'c2', True]
         ], self.explorer.get_tabular(False))
 

--- a/tests/test_dbexplorer.py
+++ b/tests/test_dbexplorer.py
@@ -38,7 +38,7 @@ class ExplorerTest(TestCase):
         self.assertEqual([
             ['testSchema', 't1', 'c1', False],
             ['testSchema', 't1', 'c2', True]
-        ], self.explorer.get_tabular())
+        ], self.explorer.get_tabular(False))
 
 
 pii_data_script = """
@@ -430,7 +430,7 @@ class TestDispatcher(TestCase):
         with mock.patch('piicatcher.db.explorer.SqliteExplorer.scan', autospec=True) as mock_scan_method:
             with mock.patch('piicatcher.db.explorer.SqliteExplorer.get_tabular', autospec=True) as mock_tabular_method:
                 with mock.patch('piicatcher.db.explorer.tableprint', autospec=True) as MockTablePrint:
-                    dispatch(Namespace(host='connection', output_format='ascii_table', connection_type='sqlite',
+                    dispatch(Namespace(host='connection', list_all=None, output_format='ascii_table', connection_type='sqlite',
                                        scan_type=None, port=None))
                     mock_scan_method.assert_called_once()
                     mock_tabular_method.assert_called_once()
@@ -442,6 +442,7 @@ class TestDispatcher(TestCase):
                 with mock.patch('piicatcher.db.explorer.tableprint', autospec=True) as MockTablePrint:
                     dispatch(Namespace(host='connection',
                                        port=None,
+                                       list_all=None,
                                        output_format='ascii_table',
                                        connection_type='mysql',
                                        scan_type='deep',
@@ -457,6 +458,7 @@ class TestDispatcher(TestCase):
                 with mock.patch('piicatcher.db.explorer.tableprint', autospec=True) as MockTablePrint:
                     dispatch(Namespace(host='connection',
                                        port=None,
+                                       list_all=None,
                                        output_format='ascii_table',
                                        connection_type='postgres',
                                        database='public',
@@ -473,6 +475,7 @@ class TestDispatcher(TestCase):
                 with mock.patch('piicatcher.db.explorer.tableprint', autospec=True) as MockTablePrint:
                     dispatch(Namespace(host='connection',
                                        port=None,
+                                       list_all=None,
                                        output_format='ascii_table',
                                        connection_type='mysql',
                                        user='user',

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -71,6 +71,7 @@ class ColumnNameScannerTests(TestCase):
 
     def test_email(self):
         self.assertTrue(PiiTypes.EMAIL in self.parser.scan("email"))
+        self.assertTrue(PiiTypes.EMAIL in self.parser.scan("EMAIL"))
 
     def test_birth_date(self):
         self.assertTrue(PiiTypes.BIRTH_DATE in self.parser.scan("dob"))


### PR DESCRIPTION
Regexes ignore case
Add an option to not list all the columns.
Oracle query add a literal for schema