### PR TITLE
fix: Support include/exclude lists for aws athena

### DIFF
--- a/piicatcher/explorer/aws.py
+++ b/piicatcher/explorer/aws.py
@@ -4,6 +4,8 @@ from argparse import Namespace
 import click
 import pyathena
 
+from piicatcher.explorer.databases import schema_help_text, exclude_schema_help_text, table_help_text, \
+    exclude_table_help_text
 from piicatcher.explorer.explorer import Explorer
 from piicatcher.catalog.glue import GlueStore
 
@@ -25,7 +27,12 @@ from piicatcher.catalog.glue import GlueStore
                    "then report is printed to sys.stdout")
 @click.option("--list-all", default=False, is_flag=True,
               help="List all columns. By default only columns with PII information is listed")
-def cli(cxt, access_key, secret_key, staging_dir, region, output_format, scan_type, output, list_all):
+@click.option("-n", "--schema", multiple=True, help=schema_help_text)
+@click.option("-N", "--exclude-schema", multiple=True, help=exclude_schema_help_text)
+@click.option("-t", "--table", multiple=True, help=table_help_text)
+@click.option("-T", "--exclude-table", multiple=True, help=exclude_table_help_text)
+def cli(cxt, access_key, secret_key, staging_dir, region, output_format, scan_type, output, list_all,
+        schema, exclude_schema, table, exclude_table):
     ns = Namespace(access_key=access_key,
                    secret_key=secret_key,
                    staging_dir=staging_dir,
@@ -34,6 +41,10 @@ def cli(cxt, access_key, secret_key, staging_dir, region, output_format, scan_ty
                    scan_type=scan_type,
                    output=output,
                    list_all=list_all,
+                   include_schema=schema,
+                   exclude_schema=exclude_schema,
+                   include_table=table,
+                   exclude_table=exclude_table,
                    catalog=cxt.obj['catalog'])
     logging.debug(vars(ns))
     AthenaExplorer.dispatch(ns)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -263,7 +263,11 @@ class TestAWSParser(TestCase):
     @patch('piicatcher.explorer.aws.AthenaExplorer')
     def test_host_user_password(self, explorer):
         runner = CliRunner()
-        result = runner.invoke(cli, ["aws", "-a", "AAAA", "-s", "SSSS", "-d", "s3://dir", "-r", "us-east"])
+        result = runner.invoke(cli, ["aws", "-a", "AAAA", "-s", "SSSS", "-d", "s3://dir", "-r", "us-east",
+                                     "-n", "include_schema", "-n", "include_schema_2",
+                                     "-N", "exclude_schema", "-N", "exclude_schema_2",
+                                     "-t", "include_table", "-t", "include_table_2",
+                                     "-T", "exclude_table", "-T", "exclude_table_2"])
         self.assertEqual("", result.stdout)
         self.assertEqual(0, result.exit_code)
         explorer.dispatch.assert_called_once_with(Namespace(
@@ -275,5 +279,9 @@ class TestAWSParser(TestCase):
             scan_type='shallow',
             secret_key='SSSS',
             staging_dir='s3://dir',
+            include_schema=("include_schema", "include_schema_2"),
+            exclude_schema=("exclude_schema", "exclude_schema_2"),
+            include_table=("include_table", "include_table_2"),
+            exclude_table=("exclude_table", "exclude_table_2"),
             catalog={'host': None, 'port': None, 'user': None, 'password': None}))
 

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -123,6 +123,10 @@ region='us-east'
 scan_type='deep'
 secret_key='SSSS'
 staging_dir='s3://dir'
+schema=["schema1", "schema2"]
+exclude_schema=["schema1", "schema2"]
+table=["table1", "table2"]
+exclude_table=["table1", "table2"]
 """)
 
     logging.info("Config File: %s" % config_file)
@@ -141,5 +145,9 @@ staging_dir='s3://dir'
         scan_type='deep',
         secret_key='SSSS',
         staging_dir='s3://dir',
+        include_schema=("schema1", "schema2"),
+        exclude_schema=("schema1", "schema2"),
+        include_table=("table1", "table2"),
+        exclude_table=("table1", "table2"),
         catalog={'host': None, 'port': None, 'user': None, 'password': None}))
 


### PR DESCRIPTION
Support was missed in previous commit.

Again - fix #56