### PR TITLE
change: Support --catalog-format and deprecate --output-format

### DIFF
--- a/piicatcher/command_line.py
+++ b/piicatcher/command_line.py
@@ -14,12 +14,19 @@ from piicatcher import __version__
 @click.version_option(__version__)
 @click_config_file.configuration_option()
 @click.option("-l", "--log-level", help="Logging Level", default="WARNING")
+@click.option("--catalog-format", type=click.Choice(["ascii_table", "json", "db", "glue"]),
+              default="ascii_table",
+              help="Choose output format type")
+@click.option("--catalog-file", default=None, type=click.File(),
+              help="File path of the catalog if format is json. If not specified, "
+                   "then report is printed to sys.stdout")
 @click.option("--catalog-host", help="Hostname of the database. Use if output is a db")
 @click.option("--catalog-port", help="Port of database. Use if output is a db")
 @click.option("--catalog-user", help="Username to connect database.  Use if output is a db")
 @click.option("--catalog-password", help="Password of the user. Use if output is a db")
 # pylint: disable=too-many-arguments
-def cli(ctx, log_level, catalog_host, catalog_port, catalog_user, catalog_password):
+def cli(ctx, log_level, catalog_format, catalog_file,
+        catalog_host, catalog_port, catalog_user, catalog_password):
     logging.basicConfig(level=getattr(logging, log_level.upper()))
     logging.debug("Catalog - host: {0}, port: {1}, user: {2}, password: {3}".format(
                   catalog_host,
@@ -34,6 +41,8 @@ def cli(ctx, log_level, catalog_host, catalog_port, catalog_user, catalog_passwo
         'port': catalog_port,
         'user': catalog_user,
         'password': catalog_password,
+        'format': catalog_format,
+        'file': catalog_file
     }
 
 

--- a/piicatcher/explorer/databases.py
+++ b/piicatcher/explorer/databases.py
@@ -62,14 +62,11 @@ tables matching -T are excluded from what is otherwise a normal dump.
               type=click.Choice(["mysql", "postgres", "redshift", "oracle", "sqlserver"]),
               help="Type of database")
 @click.option("-f", "--output-format", type=click.Choice(["ascii_table", "json", "db"]),
-              default="ascii_table",
-              help="Choose output format type")
-@click.option("-c", "--scan-type", default='shallow',
-              type=click.Choice(["deep", "shallow"]),
+              help="DEPRECATED. Please use --catalog-format")
+@click.option("-c", "--scan-type", type=click.Choice(["deep", "shallow"]), default='shallow',
               help="Choose deep(scan data) or shallow(scan column names only)")
 @click.option("-o", "--output", default=None, type=click.File(),
-              help="File path for report. If not specified, "
-                   "then report is printed to sys.stdout")
+              help="DEPRECATED. Please use --catalog-file")
 @click.option("--list-all", default=False, is_flag=True,
               help="List all columns. By default only columns with PII information is listed")
 @click.option("-n", "--schema", multiple=True, help=schema_help_text)
@@ -85,15 +82,23 @@ def cli(cxt, host, port, user, password, database, connection_type,
                    password=password,
                    database=database,
                    connection_type=connection_type,
-                   output_format=output_format,
                    scan_type=scan_type,
-                   output=output,
                    list_all=list_all,
                    catalog=cxt.obj['catalog'],
                    include_schema=schema,
                    exclude_schema=exclude_schema,
                    include_table=table,
                    exclude_table=exclude_table)
+
+    if output_format is not None or output is not None:
+        logging.warning("--output-format and --output is deprecated. "
+                        "Please use --catalog-format and --catalog-file")
+
+    if output_format is not None:
+        ns.catalog['format'] = output_format
+
+    if output is not None:
+        ns.catalog['file'] = output
 
     logging.debug(vars(ns))
     RelDbExplorer.dispatch(ns)

--- a/piicatcher/explorer/explorer.py
+++ b/piicatcher/explorer/explorer.py
@@ -63,12 +63,12 @@ class Explorer(ABC):
 
     @classmethod
     def output(cls, ns, explorer):
-        if ns.output_format == "ascii_table":
+        if ns.catalog['format'] == "ascii_table":
             headers = ["schema", "table", "column", "has_pii"]
             tableprint.table(explorer.get_tabular(ns.list_all), headers)
-        elif ns.output_format == "json":
+        elif ns.catalog['format'] == "json":
             print(json.dumps(explorer.get_dict(), sort_keys=True, indent=2, cls=PiiTypeEncoder))
-        elif ns.output_format == "db":
+        elif ns.catalog['format'] == "db":
             DbStore.save_schemas(explorer)
 
     def get_connection(self):

--- a/piicatcher/explorer/sqlite.py
+++ b/piicatcher/explorer/sqlite.py
@@ -13,14 +13,12 @@ from piicatcher.explorer.explorer import Explorer
 @click.pass_context
 @click.option("-s", "--path", required=True, help="File path to SQLite database")
 @click.option("-f", "--output-format", type=click.Choice(["ascii_table", "json", "db"]),
-              default="ascii_table",
-              help="Choose output format type")
+              help="DEPRECATED. Please use --catalog-format")
 @click.option("-c", "--scan-type", default='shallow',
               type=click.Choice(["deep", "shallow"]),
               help="Choose deep(scan data) or shallow(scan column names only)")
 @click.option("-o", "--output", default=None, type=click.File(),
-              help="File path for report. If not specified, "
-                   "then report is printed to sys.stdout")
+              help="DEPRECATED. Please use --catalog-file")
 @click.option("--list-all", default=False, is_flag=True,
               help="List all columns. By default only columns with PII information is listed")
 @click.option("-n", "--schema", multiple=True, help=schema_help_text)
@@ -31,15 +29,23 @@ from piicatcher.explorer.explorer import Explorer
 def cli(cxt, path, output_format, scan_type, output, list_all,
         schema, exclude_schema, table, exclude_table):
     args = Namespace(path=path,
-                     output_format=output_format,
                      scan_type=scan_type,
-                     output=output,
                      list_all=list_all,
                      catalog=cxt.obj['catalog'],
                      include_schema=schema,
                      exclude_schema=exclude_schema,
                      include_table=table,
                      exclude_table=exclude_table)
+
+    if output_format is not None or output is not None:
+        logging.warning("--output-format and --output is deprecated. "
+                        "Please use --catalog-format and --catalog-file")
+
+    if output_format is not None:
+        args.catalog['format'] = output_format
+
+    if output is not None:
+        args.catalog['file'] = output
 
     SqliteExplorer.dispatch(args)
 

--- a/tests/test_awsexplorer.py
+++ b/tests/test_awsexplorer.py
@@ -16,8 +16,9 @@ def test_aws_dispatch():
                                                   staging_dir='s3://DIR',
                                                   region='us-east-1',
                                                   scan_type=None,
-                                                  output_format="ascii_table",
-                                                  catalog=None,
+                                                  catalog={
+                                                      'format': 'ascii_table'
+                                                  },
                                                   include_schema=(),
                                                   exclude_schema=(),
                                                   include_table=(),

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -24,8 +24,6 @@ class TestDbParser(TestCase):
                                                             database='',
                                                             host='connection_string',
                                                             list_all=False,
-                                                            output=None,
-                                                            output_format='ascii_table',
                                                             password=None,
                                                             port=None,
                                                             scan_type='shallow',
@@ -35,7 +33,9 @@ class TestDbParser(TestCase):
                                                             include_table=(),
                                                             exclude_table=(),
                                                             catalog={'host': None, 'port': None,
-                                                                     'user': None, 'password': None}))
+                                                                     'user': None, 'password': None,
+                                                                     'format': 'ascii_table',
+                                                                     'file': None}))
 
     @patch('piicatcher.explorer.databases.RelDbExplorer')
     def test_port(self, explorer):
@@ -47,8 +47,6 @@ class TestDbParser(TestCase):
                                                             database='',
                                                             host='connection_string',
                                                             list_all=False,
-                                                            output=None,
-                                                            output_format='ascii_table',
                                                             password=None,
                                                             port=6032,
                                                             scan_type='shallow',
@@ -58,7 +56,9 @@ class TestDbParser(TestCase):
                                                             include_table=(),
                                                             exclude_table=(),
                                                             catalog={'host': None, 'port': None,
-                                                                     'user': None, 'password': None}))
+                                                                     'user': None, 'password': None,
+                                                                     'format': 'ascii_table',
+                                                                     'file': None}))
 
     @patch('piicatcher.explorer.databases.RelDbExplorer')
     def test_host_user_password(self, explorer):
@@ -70,8 +70,6 @@ class TestDbParser(TestCase):
                                                             database='',
                                                             host='connection_string',
                                                             list_all=False,
-                                                            output=None,
-                                                            output_format='ascii_table',
                                                             password='passwd',
                                                             port=None,
                                                             scan_type='shallow',
@@ -81,7 +79,9 @@ class TestDbParser(TestCase):
                                                             include_table=(),
                                                             exclude_table=(),
                                                             catalog={'host': None, 'port': None,
-                                                                     'user': None, 'password': None}))
+                                                                     'user': None, 'password': None,
+                                                                     'format': 'ascii_table',
+                                                                     'file': None}))
 
     @patch('piicatcher.explorer.databases.RelDbExplorer')
     def test_deep_scan_type(self, explorer):
@@ -93,8 +93,6 @@ class TestDbParser(TestCase):
                                                             database='',
                                                             host='connection_string',
                                                             list_all=False,
-                                                            output=None,
-                                                            output_format='ascii_table',
                                                             password=None,
                                                             port=None,
                                                             scan_type='deep',
@@ -104,7 +102,9 @@ class TestDbParser(TestCase):
                                                             include_table=(),
                                                             exclude_table=(),
                                                             catalog={'host': None, 'port': None,
-                                                                     'user': None, 'password': None}))
+                                                                     'user': None, 'password': None,
+                                                                     'format': 'ascii_table',
+                                                                     'file': None}))
 
     @patch('piicatcher.explorer.databases.RelDbExplorer')
     def test_shallow_scan_type(self, explorer):
@@ -116,8 +116,6 @@ class TestDbParser(TestCase):
                                                             database='',
                                                             host='connection_string',
                                                             list_all=False,
-                                                            output=None,
-                                                            output_format='ascii_table',
                                                             password=None,
                                                             port=None,
                                                             scan_type='shallow',
@@ -127,7 +125,9 @@ class TestDbParser(TestCase):
                                                             include_table=(),
                                                             exclude_table=(),
                                                             catalog={'host': None, 'port': None,
-                                                                     'user': None, 'password': None}))
+                                                                     'user': None, 'password': None,
+                                                                     'format': 'ascii_table',
+                                                                     'file': None}))
 
     @patch('piicatcher.explorer.databases.RelDbExplorer')
     def test_include_exclude(self, explorer):
@@ -144,8 +144,6 @@ class TestDbParser(TestCase):
                                                             database='',
                                                             host='connection_string',
                                                             list_all=False,
-                                                            output=None,
-                                                            output_format='ascii_table',
                                                             password=None,
                                                             port=None,
                                                             scan_type='shallow',
@@ -155,7 +153,9 @@ class TestDbParser(TestCase):
                                                             include_table=("include_table",),
                                                             exclude_table=("exclude_table",),
                                                             catalog={'host': None, 'port': None,
-                                                                     'user': None, 'password': None}))
+                                                                     'user': None, 'password': None,
+                                                                     'format': 'ascii_table',
+                                                                     'file': None}))
 
     @patch('piicatcher.explorer.databases.RelDbExplorer')
     def test_include_exclude_multiple(self, explorer):
@@ -172,8 +172,6 @@ class TestDbParser(TestCase):
                                                             database='',
                                                             host='connection_string',
                                                             list_all=False,
-                                                            output=None,
-                                                            output_format='ascii_table',
                                                             password=None,
                                                             port=None,
                                                             scan_type='shallow',
@@ -183,7 +181,9 @@ class TestDbParser(TestCase):
                                                             include_table=("include_table", "include_table_2"),
                                                             exclude_table=("exclude_table", "exclude_table_2"),
                                                             catalog={'host': None, 'port': None,
-                                                                     'user': None, 'password': None}))
+                                                                     'user': None, 'password': None,
+                                                                     'format': 'ascii_table',
+                                                                     'file': None}))
 
 
 class TestSqliteParser(TestCase):
@@ -207,15 +207,15 @@ class TestSqliteParser(TestCase):
         self.assertEqual(0, result.exit_code)
         explorer.dispatch.assert_called_once_with(Namespace(
             list_all=False,
-            output=None,
-            output_format='ascii_table',
             path='connection_string',
             scan_type='shallow',
             include_schema=("include_schema",),
             exclude_schema=("exclude_schema",),
             include_table=("include_table",),
             exclude_table=("exclude_table",),
-            catalog={'host': None, 'port': None, 'user': None, 'password': None}))
+            catalog={'host': None, 'port': None, 'user': None, 'password': None,
+                     'format': 'ascii_table',
+                     'file': None}))
 
     @patch('piicatcher.explorer.sqlite.SqliteExplorer')
     def test_include_exclude(self, explorer):
@@ -225,15 +225,15 @@ class TestSqliteParser(TestCase):
         self.assertEqual(0, result.exit_code)
         explorer.dispatch.assert_called_once_with(Namespace(
             list_all=False,
-            output=None,
-            output_format='ascii_table',
             path='connection_string',
             scan_type='shallow',
             include_schema=(),
             exclude_schema=(),
             include_table=(),
             exclude_table=(),
-            catalog={'host': None, 'port': None, 'user': None, 'password': None}))
+            catalog={'host': None, 'port': None, 'user': None, 'password': None,
+                     'format': 'ascii_table',
+                     'file': None}))
 
     @patch('piicatcher.explorer.sqlite.SqliteExplorer')
     def test_include_exclude_multiple(self, explorer):
@@ -247,15 +247,15 @@ class TestSqliteParser(TestCase):
         self.assertEqual(0, result.exit_code)
         explorer.dispatch.assert_called_once_with(Namespace(
             list_all=False,
-            output=None,
-            output_format='ascii_table',
             path='connection_string',
             scan_type='shallow',
             include_schema=("include_schema", "include_schema_2"),
             exclude_schema=("exclude_schema", "exclude_schema_2"),
             include_table=("include_table", "include_table_2"),
             exclude_table=("exclude_table", "exclude_table_2"),
-            catalog={'host': None, 'port': None, 'user': None, 'password': None}))
+            catalog={'host': None, 'port': None, 'user': None, 'password': None,
+                     'format': 'ascii_table',
+                     'file': None}))
 
 
 class TestAWSParser(TestCase):
@@ -273,8 +273,6 @@ class TestAWSParser(TestCase):
         explorer.dispatch.assert_called_once_with(Namespace(
             access_key='AAAA',
             list_all=False,
-            output=None,
-            output_format='ascii_table',
             region='us-east',
             scan_type='shallow',
             secret_key='SSSS',
@@ -283,5 +281,7 @@ class TestAWSParser(TestCase):
             exclude_schema=("exclude_schema", "exclude_schema_2"),
             include_table=("include_table", "include_table_2"),
             exclude_table=("exclude_table", "exclude_table_2"),
-            catalog={'host': None, 'port': None, 'user': None, 'password': None}))
+            catalog={'host': None, 'port': None, 'user': None, 'password': None,
+                     'format': 'ascii_table',
+                     'file': None}))
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -130,6 +130,29 @@ class TestDbParser(TestCase):
                                                                      'file': None}))
 
     @patch('piicatcher.explorer.databases.RelDbExplorer')
+    def test_output_format(self, explorer):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["db", "-s", "connection_string", "--output-format", "json"])
+        self.assertEqual("", result.stdout)
+        self.assertEqual(0, result.exit_code)
+        explorer.dispatch.assert_called_once_with(Namespace(connection_type='mysql',
+                                                            database='',
+                                                            host='connection_string',
+                                                            list_all=False,
+                                                            password=None,
+                                                            port=None,
+                                                            scan_type='shallow',
+                                                            user=None,
+                                                            include_schema=(),
+                                                            exclude_schema=(),
+                                                            include_table=(),
+                                                            exclude_table=(),
+                                                            catalog={'host': None, 'port': None,
+                                                                     'user': None, 'password': None,
+                                                                     'format': 'json',
+                                                                     'file': None}))
+
+    @patch('piicatcher.explorer.databases.RelDbExplorer')
     def test_include_exclude(self, explorer):
         runner = CliRunner()
         result = runner.invoke(cli, ["db", "-s", "connection_string",
@@ -198,7 +221,7 @@ class TestSqliteParser(TestCase):
     @patch('piicatcher.explorer.sqlite.SqliteExplorer')
     def test_host(self, explorer):
         runner = CliRunner()
-        result = runner.invoke(cli, ["sqlite", "-s", "connection_string",
+        result = runner.invoke(cli, ["sqlite", "-s", "connection_string", "--output-format", "json",
                                      "-n", "include_schema",
                                      "-N", "exclude_schema",
                                      "-t", "include_table",
@@ -214,7 +237,7 @@ class TestSqliteParser(TestCase):
             include_table=("include_table",),
             exclude_table=("exclude_table",),
             catalog={'host': None, 'port': None, 'user': None, 'password': None,
-                     'format': 'ascii_table',
+                     'format': 'json',
                      'file': None}))
 
     @patch('piicatcher.explorer.sqlite.SqliteExplorer')
@@ -264,6 +287,7 @@ class TestAWSParser(TestCase):
     def test_host_user_password(self, explorer):
         runner = CliRunner()
         result = runner.invoke(cli, ["aws", "-a", "AAAA", "-s", "SSSS", "-d", "s3://dir", "-r", "us-east",
+                                     "--output-format", "json",
                                      "-n", "include_schema", "-n", "include_schema_2",
                                      "-N", "exclude_schema", "-N", "exclude_schema_2",
                                      "-t", "include_table", "-t", "include_table_2",
@@ -282,6 +306,6 @@ class TestAWSParser(TestCase):
             include_table=("include_table", "include_table_2"),
             exclude_table=("exclude_table", "exclude_table_2"),
             catalog={'host': None, 'port': None, 'user': None, 'password': None,
-                     'format': 'ascii_table',
+                     'format': 'json',
                      'file': None}))
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -379,10 +379,11 @@ class TestDispatcher(TestCase):
                     RelDbExplorer.dispatch(Namespace(host='connection',
                                                      port=None,
                                                      list_all=None,
-                                                     output_format='ascii_table',
                                                      connection_type='mysql',
                                                      scan_type='deep',
-                                                     catalog=None,
+                                                     catalog={
+                                                         'format': 'ascii_table'
+                                                     },
                                                      user='user',
                                                      include_schema=(),
                                                      exclude_schema=(),
@@ -403,11 +404,12 @@ class TestDispatcher(TestCase):
                     RelDbExplorer.dispatch(Namespace(host='connection',
                                                      port=None,
                                                      list_all=None,
-                                                     output_format='ascii_table',
                                                      connection_type='postgres',
                                                      database='public',
                                                      scan_type=None,
-                                                     catalog=None,
+                                                     catalog={
+                                                         'format': 'ascii_table'
+                                                     },
                                                      include_schema=(),
                                                      exclude_schema=(),
                                                      include_table=(),
@@ -428,9 +430,10 @@ class TestDispatcher(TestCase):
                     RelDbExplorer.dispatch(Namespace(host='connection',
                                                      port=None,
                                                      list_all=None,
-                                                     output_format='ascii_table',
                                                      connection_type='mysql',
-                                                     catalog=None,
+                                                     catalog={
+                                                         'format': 'ascii_table'
+                                                     },
                                                      include_schema=(),
                                                      exclude_schema=(),
                                                      include_table=(),

--- a/tests/test_file_explorer.py
+++ b/tests/test_file_explorer.py
@@ -10,7 +10,9 @@ class TestDispatcher(TestCase):
         with mock.patch('piicatcher.explorer.files.FileExplorer.scan', autospec=True) as mock_scan_method:
             with mock.patch('piicatcher.explorer.files.FileExplorer.get_tabular', autospec=True) as mock_tabular_method:
                 with mock.patch('piicatcher.explorer.files.tableprint', autospec=True) as MockTablePrint:
-                    FileExplorer.dispatch(Namespace(path='/a/b/c', output_format='ascii_table'))
+                    FileExplorer.dispatch(Namespace(path='/a/b/c', catalog={
+                        'format': 'ascii_table'
+                    }))
                     mock_scan_method.assert_called_once()
                     mock_tabular_method.assert_called_once()
                     MockTablePrint.table.assert_called_once()

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -79,8 +79,10 @@ class TestDispatcher(TestCase):
                 with mock.patch('piicatcher.explorer.explorer.tableprint', autospec=True) \
                         as mock_table_print:
                     SqliteExplorer.dispatch(Namespace(path='connection', list_all=None,
-                                                      output_format='ascii_table',
-                                                      scan_type=None, catalog=None,
+                                                      catalog={
+                                                          'format': 'ascii_table'
+                                                      },
+                                                      scan_type=None,
                                                       include_schema=(),
                                                       exclude_schema=(),
                                                       include_table=(),


### PR DESCRIPTION
This change strengthens the concept of a catalog as metadata storage.
--output-format and --output only focused reporting.

With a formal catalog, piicatcher can add a lot more features such as
incremental processing, diffs and events.