### PR TITLE
fix: Print json catalog to file if file path is specified

### DIFF
--- a/piicatcher/catalog/file.py
+++ b/piicatcher/catalog/file.py
@@ -1,0 +1,16 @@
+import json
+import sys
+
+from piicatcher.catalog import Store
+from piicatcher.piitypes import PiiTypeEncoder
+
+
+class FileStore(Store):
+    @classmethod
+    def save_schemas(cls, explorer):
+        if explorer.catalog['file'] is not None:
+            with open(explorer.catalog['file'], 'w') as fh:
+                json.dump(explorer.get_dict(), fh, sort_keys=True, indent=2, cls=PiiTypeEncoder)
+        else:
+            json.dump(explorer.get_dict(), sys.stdout, sort_keys=True, indent=2, cls=PiiTypeEncoder)
+

--- a/piicatcher/explorer/explorer.py
+++ b/piicatcher/explorer/explorer.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 import tableprint
 
+from piicatcher.catalog.file import FileStore
 from piicatcher.explorer.metadata import Schema, Table, Column, Database
 from piicatcher.catalog.db import DbStore
 from piicatcher.piitypes import PiiTypeEncoder
@@ -67,7 +68,7 @@ class Explorer(ABC):
             headers = ["schema", "table", "column", "has_pii"]
             tableprint.table(explorer.get_tabular(ns.list_all), headers)
         elif ns.catalog['format'] == "json":
-            print(json.dumps(explorer.get_dict(), sort_keys=True, indent=2, cls=PiiTypeEncoder))
+            FileStore.save_schemas(explorer)
         elif ns.catalog['format'] == "db":
             DbStore.save_schemas(explorer)
 

--- a/piicatcher/explorer/files.py
+++ b/piicatcher/explorer/files.py
@@ -1,3 +1,4 @@
+import sys
 from argparse import Namespace
 
 import click
@@ -7,6 +8,7 @@ import logging
 import os
 import magic
 
+from piicatcher.catalog.file import FileStore
 from piicatcher.explorer.metadata import NamedObject
 from piicatcher.piitypes import PiiTypes, PiiTypeEncoder
 from piicatcher.scanner import NERScanner, RegexScanner
@@ -74,7 +76,7 @@ class FileExplorer:
             headers = ["Path", "Mime/Type", "pii"]
             tableprint.table(explorer.get_tabular(), headers)
         elif ns.catalog['format'] == "json":
-            print(json.dumps(explorer.get_dict(), sort_keys=True, indent=2, cls=PiiTypeEncoder))
+            FileStore.save_schemas(explorer)
 
     def __init__(self, path):
         self._path = path

--- a/tests/test_filestore.py
+++ b/tests/test_filestore.py
@@ -1,0 +1,51 @@
+import json
+import sys
+from argparse import Namespace
+
+from piicatcher.catalog.file import FileStore
+from tests.test_models import MockExplorer
+
+
+def test_file(tmp_path):
+    tmp_file = tmp_path / "schema.json"
+    explorer = MockExplorer(Namespace(catalog={
+        'file': tmp_file,
+        'format': 'json'
+    },
+                                      include_schema=(),
+                                      exclude_schema=(),
+                                      include_table=(),
+                                      exclude_table=()
+                                      ))
+
+    explorer._load_catalog()
+    FileStore.save_schemas(explorer)
+    obj = None
+    with open(tmp_file, 'r') as fh:
+        obj = json.load(fh)
+    assert len(obj) > 0
+    assert obj[0]['name'] == 'test_store'
+    assert len(obj[0]['tables']) == 3
+
+
+def test_stdout(capsys):
+    explorer = MockExplorer(Namespace(catalog={
+        'file': None,
+        'format': 'json'
+    },
+                                      include_schema=(),
+                                      exclude_schema=(),
+                                      include_table=(),
+                                      exclude_table=()
+                                      ))
+
+    explorer._load_catalog()
+
+    FileStore.save_schemas(explorer)
+    out, err = capsys.readouterr()
+
+    obj = json.loads(out)
+    assert len(obj) > 0
+    assert obj[0]['name'] == 'test_store'
+    assert len(obj[0]['tables']) == 3
+


### PR DESCRIPTION
The code to print catalog to was missing. Created FileStore as the
object to manage a file based catalog.

Fix #70