### PR TITLE
Removal: Remove support for MSSQL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Download and cache dependencies
       - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: deps9-{{ checksum "Pipfile.lock" }}
 
       - run:
           name: install dependencies
@@ -71,7 +71,7 @@ jobs:
             pipenv run python -m spacy download en_core_web_sm
 
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: deps9-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
 
@@ -97,14 +97,14 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: deps9-{{ checksum "Pipfile.lock" }}
       - run:
           name: install dependencies
           command: |
             sudo pip install pipenv
             pipenv install --dev
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: deps9-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ PiiCatcher supports the following databases:
 2. **MySQL** 5.6 or greater
 3. **PostgreSQL** 9.4 or greater
 4. **AWS Redshift**
-5. **SQL Server**
-6. **Oracle**
-7. **AWS Glue/AWS Athena**
+5. **Oracle**
+6. **AWS Glue/AWS Athena**
 
 ## Documentation
 

--- a/piicatcher/explorer/databases.py
+++ b/piicatcher/explorer/databases.py
@@ -4,7 +4,6 @@ from argparse import Namespace
 import click
 import pymysql
 import psycopg2
-import pymssql
 import cx_Oracle
 
 import logging
@@ -213,50 +212,6 @@ class PostgreSQLExplorer(RelDbExplorer):
     @classmethod
     def _get_sample_query(cls, schema_name, table_name, column_list):
         return cls.query_template.format(
-            column_list=",".join([col.get_name() for col in column_list]),
-            schema_name=schema_name.get_name(),
-            table_name=table_name.get_name()
-        )
-
-
-class MSSQLExplorer(RelDbExplorer):
-    _catalog_query = """
-        SELECT
-            TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE
-        FROM
-            INFORMATION_SCHEMA.COLUMNS
-        WHERE
-            DATA_TYPE LIKE '%char%'
-        ORDER BY TABLE_SCHEMA, table_name, ordinal_position
-    """
-
-    _sample_query_template = "SELECT TOP 10 * FROM {schema_name}.{table_name} TABLESAMPLE (1000 ROWS)"
-
-    def __init__(self, ns):
-        super(MSSQLExplorer, self).__init__(ns)
-        self._mssql_database = self._mssql_database if ns.database is None else ns.database
-
-    @property
-    def default_database(self):
-        return "public"
-
-    @property
-    def default_port(self):
-        return 1433
-
-    def _open_connection(self):
-        return pymssql.connect(host=self.host,
-                               port=self.port,
-                               user=self.user,
-                               password=self.password,
-                               database=self._mssql_database)
-
-    def _get_catalog_query(self):
-        return self._catalog_query
-
-    @classmethod
-    def _get_sample_query(cls, schema_name, table_name, column_list):
-        return cls._sample_query_template.format(
             column_list=",".join([col.get_name() for col in column_list]),
             schema_name=schema_name.get_name(),
             table_name=table_name.get_name()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ commonregex
 spacy
 tableprint
 pymysql
-pymssql<3.0
 cx_Oracle
 psycopg2-binary
 cryptography

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -8,7 +8,7 @@ import logging
 import pytest
 
 from piicatcher.explorer.databases import MySQLExplorer, PostgreSQLExplorer, OracleExplorer, \
-    MSSQLExplorer, RelDbExplorer
+    RelDbExplorer
 from piicatcher.explorer.sqlite import SqliteExplorer
 from piicatcher.explorer.metadata import Schema, Table, Column
 from piicatcher.piitypes import PiiTypes
@@ -357,12 +357,6 @@ class SelectQueryTest(TestCase):
     def test_mysql(self):
         self.assertEqual("select c1,c2 from testSchema.t1",
                          MySQLExplorer._get_select_query(self.schema,
-                                                         self.schema.get_children()[0],
-                                                         self.schema.get_children()[0].get_children()))
-
-    def test_mssql(self):
-        self.assertEqual("select c1,c2 from testSchema.t1",
-                         MSSQLExplorer._get_select_query(self.schema,
                                                          self.schema.get_children()[0],
                                                          self.schema.get_children()[0].get_children()))
 


### PR DESCRIPTION
SQL Server support is removed because pymssql is not supported anymore.
Check #72 for issues in installing 2.x versions of the library in 3.8.1.
Even with Cython, the library does not install due to build issues.

Fix #29