### PR TITLE
fix: Fix storing file explorer to file catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ PIICatcher supports the following databases:
 
 ## Documentation
 
-For advanced usage refer documentation [at its website](https://tokern.io/docs/piicatcher).
+For advanced usage refer documentation [PIICatcher Documentation](https://tokern.io/docs/piicatcher).
 
 ## Contributing
 
-For Contribution guidelines, [refer to developer documentation](https://tokern.io/docs/piicatcher/development). 
+For Contribution guidelines, [PIICatcher Developer documentation](https://tokern.io/docs/piicatcher/development). 
 

--- a/piicatcher/explorer/explorer.py
+++ b/piicatcher/explorer/explorer.py
@@ -8,7 +8,6 @@ import tableprint
 from piicatcher.catalog.file import FileStore
 from piicatcher.explorer.metadata import Schema, Table, Column, Database
 from piicatcher.catalog.db import DbStore
-from piicatcher.piitypes import PiiTypeEncoder
 
 
 class Explorer(ABC):

--- a/piicatcher/explorer/files.py
+++ b/piicatcher/explorer/files.py
@@ -69,7 +69,7 @@ class FileExplorer:
     @classmethod
     def dispatch(cls, ns):
         logging.debug("File Dispatch entered")
-        explorer = FileExplorer(ns.path)
+        explorer = cls(ns)
         explorer.scan()
 
         if ns.catalog['format'] == "ascii_table":
@@ -78,9 +78,10 @@ class FileExplorer:
         elif ns.catalog['format'] == "json":
             FileStore.save_schemas(explorer)
 
-    def __init__(self, path):
-        self._path = path
+    def __init__(self, ns):
+        self._path = ns.path
         self._files = []
+        self.catalog = ns.catalog
 
     def scan(self):
         logging.debug("Scanning %s" % self._path)


### PR DESCRIPTION
Full support was missing and not tested. This commit adds tests and
support for writing catalog to json file.

Fix #76

Minor fixes:
- Remove unused imports
- Improve anchor text in README