### PR TITLE
fix: Fix database catalog operations to not overwrite records

### DIFF
--- a/piicatcher/catalog/pii_type_field.py
+++ b/piicatcher/catalog/pii_type_field.py
@@ -3,11 +3,15 @@ from peewee import Field
 from piicatcher.piitypes import PiiTypeEncoder, as_enum
 
 
+def enum_value(member):
+    return member.value
+
+
 class PiiTypeField(Field):
     field_type = "VARCHAR(255)"
 
     def db_value(self, value):
-        return json.dumps(list(value), cls=PiiTypeEncoder)
+        return json.dumps(sorted(value, key=enum_value), cls=PiiTypeEncoder)
 
     def python_value(self, value):
         return json.loads(value, object_hook=as_enum)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,8 +28,8 @@ def setup_catalog():
                          user='root',
                          password='r00tPa33w0rd',
                          database='piidb').cursor() as c:
-        c.execute("CREATE USER catalog_user IDENTIFIED BY 'catal0g_passw0rd'")
-        c.execute("CREATE DATABASE tokern")
+        c.execute("CREATE USER IF NOT EXISTS catalog_user IDENTIFIED BY 'catal0g_passw0rd'")
+        c.execute("CREATE DATABASE IF NOT EXISTS tokern")
         c.execute("GRANT ALL ON tokern.* TO 'catalog_user'@'%'")
 
 
@@ -108,32 +108,97 @@ def setup_explorer(request, setup_catalog):
     request.addfinalizer(finalizer)
 
 
-def get_cursor():
+def get_connection():
     return pymysql.connect(host=catalog['host'],
                            port=catalog['port'],
                            user=catalog['user'],
                            password=catalog['password'],
-                           database='tokern').cursor()
+                           database='tokern')
 
 
 def test_schema(setup_explorer):
-    with get_cursor() as c:
-        c.execute('select * from dbschemas')
-        assert([(1, 'test_store')] == list(c.fetchall()))
+    with get_connection().cursor() as c:
+        c.execute('select name from dbschemas')
+        assert([('test_store',)] == list(c.fetchall()))
 
 
 def test_tables(setup_explorer):
-    with get_cursor() as c:
-        c.execute('select * from dbtables order by id')
-        assert([(1, 'no_pii', 1), (2, 'partial_pii', 1), (3, 'full_pii', 1)] == list(c.fetchall()))
+    with get_connection().cursor() as c:
+        c.execute('select name from dbtables order by id')
+        assert([('no_pii',), ('partial_pii',), ('full_pii',)] == list(c.fetchall()))
 
 
 def test_columns(setup_explorer):
-    with get_cursor() as c:
-        c.execute('select * from dbcolumns where table_id in (1,2) order by id')
+    with get_connection().cursor() as c:
+        c.execute("select name, pii_type from dbcolumns order by id")
         assert(
-            [(1, 'a', '[]', 1),
-             (2, 'b', '[]', 1),
-             (3, 'a', '[{"__enum__": "PiiTypes.PHONE"}]', 2),
-             (4, 'b', '[]', 2)] == list(c.fetchall()))
+            [('a', '[]'),
+             ('b', '[]'),
+             ('a', '[{"__enum__": "PiiTypes.PHONE"}]'),
+             ('b', '[]'),
+             ('a', '[{"__enum__": "PiiTypes.PHONE"}]'),
+             ('b', '[{"__enum__": "PiiTypes.ADDRESS"}, {"__enum__": "PiiTypes.LOCATION"}]')] == list(c.fetchall()))
+
+
+def test_setup_database(setup_explorer):
+    DbStore.setup_database(catalog=catalog)
+    with get_connection().cursor() as c:
+        c.execute('select name from dbtables order by id')
+        assert([('no_pii',), ('partial_pii',), ('full_pii',)] == list(c.fetchall()))
+
+
+def test_out_of_band_update(setup_explorer):
+    connection = get_connection()
+    with connection.cursor() as c:
+        c.execute("select id from dbtables where name = 'partial_pii'")
+        table_id = c.fetchone()[0]
+        c.execute("""
+            update dbcolumns set pii_type='[{{"__enum__": "PiiTypes.CREDIT_CARD"}}]'
+            where table_id = {0} and name = 'b' 
+            """.format(table_id))
+
+    connection.commit()
+
+    with connection.cursor() as c:
+        c.execute('select name, pii_type from dbcolumns where table_id = {0} order by id'.format(table_id))
+        assert(
+             [('a', '[{"__enum__": "PiiTypes.PHONE"}]'),
+              ('b', '[{"__enum__": "PiiTypes.CREDIT_CARD"}]')] == list(c.fetchall()))
+
+
+class UpdateColumnExplorer(MockExplorer):
+    @staticmethod
+    def get_partial_pii_table():
+        partial_pii_table = Table("test_store", "partial_pii")
+        partial_pii_a = Column("a")
+        partial_pii_a.add_pii_type(PiiTypes.PHONE)
+        partial_pii_b = Column("b")
+        partial_pii_b.add_pii_type(PiiTypes.ADDRESS)
+
+        partial_pii_table.add_child(partial_pii_a)
+        partial_pii_table.add_child(partial_pii_b)
+
+        return partial_pii_table
+
+
+def test_update(setup_explorer):
+    ns = Namespace(catalog=catalog,
+                   include_schema=(),
+                   exclude_schema=(),
+                   include_table=(),
+                   exclude_table=()
+                   )
+    explorer = UpdateColumnExplorer(ns)
+    UpdateColumnExplorer.output(ns, explorer)
+
+    connection = get_connection()
+    with connection.cursor() as c:
+        c.execute("select id from dbtables where name = 'partial_pii'")
+        table_id = c.fetchone()[0]
+
+    with connection.cursor() as c:
+        c.execute('select name, pii_type from dbcolumns where table_id = {0} order by id'.format(table_id))
+        assert(
+             [('a', '[{"__enum__": "PiiTypes.PHONE"}]'),
+              ('b', '[{"__enum__": "PiiTypes.CREDIT_CARD"}]')] == list(c.fetchall()))
 


### PR DESCRIPTION
Do not add duplicate rows and columns. Instead get or create records.
Do not overwrite manual updates in PII.

Fix #90