### PR TITLE
fix: Fix incompatible botocore versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pyyaml
 python-magic~=0.4.15
 pyathena[sqlalchemy]~=1.10.2
 boto3 == 1.12.1
+botocore == 1.15.49
 click == 7.0
 click-config-file == 0.5.0
-snowflake-connector-python == 2.2.5
+snowflake-connector-python == 2.2.7


### PR DESCRIPTION
Different botocore versions were downloaded by boto3, pyathena and
snowflake connector. Upgrade snowflake connector and fix botocore
version to remove the dependency.

Fix #96