### PR TITLE
fix: Fix errors in --catalog-file and handling csv

### DIFF
--- a/piicatcher/catalog/file.py
+++ b/piicatcher/catalog/file.py
@@ -9,14 +9,13 @@ class FileStore(Store):
     @classmethod
     def save_schemas(cls, explorer):
         if explorer.catalog["file"] is not None:
-            with open(explorer.catalog["file"], "w") as fh:
-                json.dump(
-                    explorer.get_dict(),
-                    fh,
-                    sort_keys=True,
-                    indent=2,
-                    cls=PiiTypeEncoder,
-                )
+            json.dump(
+                explorer.get_dict(),
+                explorer.catalog["file"],
+                sort_keys=True,
+                indent=2,
+                cls=PiiTypeEncoder,
+            )
         else:
             json.dump(
                 explorer.get_dict(),

--- a/piicatcher/command_line.py
+++ b/piicatcher/command_line.py
@@ -25,7 +25,7 @@ from piicatcher.explorer.sqlite import cli as sqlite_cli
 @click.option(
     "--catalog-file",
     default=None,
-    type=click.File(),
+    type=click.File("w"),
     help="File path of the catalog if format is json. If not specified, "
     "then report is printed to sys.stdout",
 )

--- a/piicatcher/explorer/files.py
+++ b/piicatcher/explorer/files.py
@@ -17,31 +17,8 @@ from piicatcher.tokenizer import Tokenizer
 @click.command("files")
 @click.pass_context
 @click.option("--path", type=click.Path(), help="Path to file or directory")
-@click.option(
-    "--output",
-    type=click.File(),
-    default=None,
-    help="DEPRECATED. Please use --catalog-file",
-)
-@click.option(
-    "--output-format",
-    type=click.Choice(["ascii_table", "json", "db"]),
-    help="DEPRECATED. Please use --catalog-format",
-)
-def cli(ctx, path, output, output_format):
+def cli(ctx, path):
     ns = Namespace(path=path, catalog=ctx.obj["catalog"])
-
-    if output_format is not None or output is not None:
-        logging.warning(
-            "--output-format and --output is deprecated. "
-            "Please use --catalog-format and --catalog-file"
-        )
-
-    if output_format is not None:
-        ns.catalog["format"] = output_format
-
-    if output is not None:
-        ns.catalog["file"] = output
 
     FileExplorer.dispatch(ns)
 
@@ -59,7 +36,10 @@ class File(NamedObject):
         regex = context["regex"]
         ner = context["ner"]
 
-        if not self._mime_type.startswith("text/"):
+        if (
+            not self._mime_type.startswith("text/")
+            and self._mime_type != "application/csv"
+        ):
             self._pii.add(PiiTypes.UNSUPPORTED)
         else:
             with open(self.get_name(), "r") as f:

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -113,7 +113,6 @@ def test_files(tmp_path, mocker, caplog):
         """
 [files]
 path="file path"
-output_format="json"
 """
     )
 
@@ -132,7 +131,7 @@ output_format="json"
                 "port": None,
                 "user": None,
                 "password": None,
-                "format": "json",
+                "format": "ascii_table",
                 "file": None,
             },
         )

--- a/tests/test_file_explorer.py
+++ b/tests/test_file_explorer.py
@@ -71,6 +71,7 @@ class MockFileExplorer(FileExplorer):
 def namespace(request, tmpdir_factory):
     temp_dir = tmpdir_factory.mktemp("file_explorer_test")
     output_path = temp_dir.join("output.json")
+    fh = open(output_path)
 
     def finalizer():
         rmtree(temp_dir)
@@ -78,7 +79,9 @@ def namespace(request, tmpdir_factory):
 
     request.addfinalizer(finalizer)
 
-    return Namespace(path=temp_dir, catalog={"format": "json", "file": output_path})
+    return Namespace(
+        path=temp_dir, catalog={"format": "json", "file": fh}, output_path=output_path
+    )
 
 
 def test_tabular(namespace):
@@ -107,7 +110,9 @@ def test_dict(namespace):
 
 def test_output_json(request, namespace):
     MockFileExplorer.dispatch(namespace)
-    obj = json.load(namespace.catalog["file"])
+    namespace.catalog["file"].close()
+
+    obj = json.load(namespace.output_path)
     assert obj == {
         "files": [
             {

--- a/tests/test_file_explorer.py
+++ b/tests/test_file_explorer.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from argparse import Namespace
 from shutil import rmtree
 from unittest import TestCase, mock
@@ -108,20 +107,18 @@ def test_dict(namespace):
 
 def test_output_json(request, namespace):
     MockFileExplorer.dispatch(namespace)
-    assert os.path.isfile(namespace.catalog["file"])
-    with open(namespace.catalog["file"], "r") as output:
-        obj = json.load(output)
-        assert obj == {
-            "files": [
-                {
-                    "Mime/Type": "text/plain",
-                    "path": "/tmp/1",
-                    "pii": [{"__enum__": "PiiTypes.BIRTH_DATE"}],
-                },
-                {
-                    "Mime/Type": "application/pdf",
-                    "path": "/tmp/2",
-                    "pii": [{"__enum__": "PiiTypes.UNSUPPORTED"}],
-                },
-            ]
-        }
+    obj = json.load(namespace.catalog["file"])
+    assert obj == {
+        "files": [
+            {
+                "Mime/Type": "text/plain",
+                "path": "/tmp/1",
+                "pii": [{"__enum__": "PiiTypes.BIRTH_DATE"}],
+            },
+            {
+                "Mime/Type": "application/pdf",
+                "path": "/tmp/2",
+                "pii": [{"__enum__": "PiiTypes.UNSUPPORTED"}],
+            },
+        ]
+    }

--- a/tests/test_file_explorer.py
+++ b/tests/test_file_explorer.py
@@ -71,7 +71,7 @@ class MockFileExplorer(FileExplorer):
 def namespace(request, tmpdir_factory):
     temp_dir = tmpdir_factory.mktemp("file_explorer_test")
     output_path = temp_dir.join("output.json")
-    fh = open(output_path)
+    fh = open(output_path, "w")
 
     def finalizer():
         rmtree(temp_dir)

--- a/tests/test_filestore.py
+++ b/tests/test_filestore.py
@@ -7,9 +7,10 @@ from tests.test_models import MockExplorer
 
 def test_file(tmp_path):
     tmp_file = tmp_path / "schema.json"
+    tmp_fh = open(tmp_file, "w")
     explorer = MockExplorer(
         Namespace(
-            catalog={"file": tmp_file, "format": "json"},
+            catalog={"file": tmp_fh, "format": "json"},
             include_schema=(),
             exclude_schema=(),
             include_table=(),

--- a/tests/test_filestore.py
+++ b/tests/test_filestore.py
@@ -17,7 +17,7 @@ def test_file(tmp_path):
             exclude_table=(),
         )
     )
-
+    tmp_fh.close()
     explorer._load_catalog()
     FileStore.save_schemas(explorer)
     obj = None

--- a/tests/test_filestore.py
+++ b/tests/test_filestore.py
@@ -17,9 +17,9 @@ def test_file(tmp_path):
             exclude_table=(),
         )
     )
-    tmp_fh.close()
     explorer._load_catalog()
     FileStore.save_schemas(explorer)
+    tmp_fh.close()
     obj = None
     with open(tmp_file, "r") as fh:
         obj = json.load(fh)


### PR DESCRIPTION
--catalog-file expected a file to exist because of wrong usage of
Click.file()

On some systems, mime_type of csv files in "application/csv".

Remove output and output-format support in files.

Fix #106
Fix #107