### PR TITLE
feature: Document docker usage. Upload latest image on release.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,3 +154,8 @@ jobs:
           command: |
             ~/go/bin/git-chglog $CIRCLE_TAG | ~/go/bin/github-release release --description - --tag $CIRCLE_TAG
 
+      - run:
+          name: build docker and publish
+          command: |
+            ./build_image.sh $CIRCLE_TAG --publish --latest
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/piicatcher.svg)](https://pypi.python.org/pypi/piicatcher)
 [![image](https://img.shields.io/pypi/l/piicatcher.svg)](https://pypi.org/project/piicatcher/)
 [![image](https://img.shields.io/pypi/pyversions/piicatcher.svg)](https://pypi.org/project/piicatcher/)
+[![image](https://img.shields.io/docker/v/tokern/piicatcher)](https://hub.docker.com/r/tokern/piicatcher)
 
 # PII Catcher for Files and Databases
 
@@ -16,8 +17,24 @@ Check out [AWS Glue & Lake Formation Privilege Analyzer](https://tokern.io/blog/
 
 ## Quick Start
 
-PIICatcher is available as a command-line application.
+PIICatcher is available as a docker image or command-line application.
 
+### Docker
+
+    docker run tokern/piicatcher:latest db -c '/db/sqlqb'
+
+    ╭─────────────┬─────────────┬─────────────┬─────────────╮
+    │   schema    │    table    │   column    │   has_pii   │
+    ├─────────────┼─────────────┼─────────────┼─────────────┤
+    │        main │    full_pii │           a │           1 │
+    │        main │    full_pii │           b │           1 │
+    │        main │      no_pii │           a │           0 │
+    │        main │      no_pii │           b │           0 │
+    │        main │ partial_pii │           a │           1 │
+    │        main │ partial_pii │           b │           0 │
+    ╰─────────────┴─────────────┴─────────────┴─────────────╯
+
+### Command-line
 To install use pip:
 
     python3 -m venv .env

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,62 @@
+#! /usr/bin/env bash
+
+set -e
+
+PROJECT_ROOT=$(dirname $(dirname $0))
+
+echo "$PROJECT_ROOT"
+
+DOCKERHUB_NAMESPACE=tokern
+
+
+TAG=$1
+if [ -z $TAG ]; then
+    echo "usage: $0 <release-name> [--publish] [--latest]"
+    exit 1
+fi
+
+if [ "$2" == "--publish" ]; then
+    PUBLISH="YES"
+fi
+
+if [ "$3" == "--latest" ]; then
+    LATEST="YES"
+fi
+
+if [ "$PUBLISH" == "YES" ] && [ -z "$DOCKERHUB_USERNAME" -o -z "$DOCKERHUB_PASSWORD" ]; then
+    echo "In order to publish an image to Dockerhub you must set \$DOCKERHUB_USERNAME and \$DOCKERHUB_PASSWORD before running."
+    exit 1
+fi
+
+DOCKERHUB_REPOSITORY=piicatcher
+DOCKER_IMAGE="${DOCKERHUB_NAMESPACE}/${DOCKERHUB_REPOSITORY}:${TAG}"
+
+echo "Building Docker image ${DOCKER_IMAGE} from official Tokern release ${TAG}"
+
+# now tell docker to build our image
+
+docker build -t "${DOCKER_IMAGE}" -f "$PROJECT_ROOT"/Dockerfile "${PROJECT_ROOT}"
+
+if [ "$PUBLISH" == "YES" ]; then
+    echo "Publishing image ${DOCKER_IMAGE} to Dockerhub"
+
+    # make sure that we are logged into dockerhub
+    docker login --username="${DOCKERHUB_USERNAME}" --password="${DOCKERHUB_PASSWORD}"
+
+    # push the built image to dockerhub
+    docker push "${DOCKER_IMAGE}"
+
+    # TODO: quick check against dockerhub to see that our new image made it
+
+    if [ "$LATEST" == "YES" ]; then
+        # tag our recent versioned image as "latest"
+        docker tag "${DOCKER_IMAGE}" ${DOCKERHUB_NAMESPACE}/${DOCKERHUB_REPOSITORY}:latest
+
+        # then push it as well
+        docker push ${DOCKERHUB_NAMESPACE}/${DOCKERHUB_REPOSITORY}:latest
+
+        # TODO: validate push succeeded
+    fi
+fi
+
+echo "Done"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tableprint~=0.8.0
 pymysql~=0.9.3
 cx_Oracle
 psycopg2-binary
-cryptography
+cryptography == 2.9.2
 peewee~=3.13.1
 pyyaml
 python-magic~=0.4.15


### PR DESCRIPTION
use build_image.sh as it is easy to debug the script compared to
circleci config file.

Pin cryptography version as snowflake connector does not work with the
latest version.

@n2taylor FYI. This commit adds scripts to release a docker image for every semver tag. 