### PR TITLE
feature: Add a progress bar. Support deep scans in Athena

### DIFF
--- a/piicatcher/__init__.py
+++ b/piicatcher/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-__version__ = "0.17.5"
+__version__ = "0.18.0"

--- a/piicatcher/api.py
+++ b/piicatcher/api.py
@@ -65,7 +65,10 @@ def scan_database(
         if incremental:
             last_task = catalog.get_latest_task("piicatcher.{}".format(source.name))
             last_run = last_task.updated_at if last_task is not None else None
-            LOGGER.debug("Last Run at {}", last_run)
+            if last_run is not None:
+                LOGGER.debug("Last Run at {}", last_run)
+            else:
+                LOGGER.debug("No last run found")
 
         try:
             scanner = DbScanner(
@@ -97,6 +100,15 @@ def scan_database(
             else:
                 deep_scan(
                     catalog=catalog,
+                    work_generator=column_generator(
+                        catalog=catalog,
+                        source=source,
+                        last_run=last_run,
+                        exclude_schema_regex_str=exclude_schema_regex,
+                        include_schema_regex_str=include_schema_regex,
+                        exclude_table_regex_str=exclude_table_regex,
+                        include_table_regex_str=include_table_regex,
+                    ),
                     generator=data_generator(
                         catalog=catalog,
                         source=source,

--- a/piicatcher/generators.py
+++ b/piicatcher/generators.py
@@ -70,7 +70,9 @@ def _get_query(
 
     if count > sample_boundary:
         try:
-            query = dbinfo.get_sample_query(schema.name, table.name, column_name_list)
+            query = dbinfo.get_sample_query(
+                schema.name, table.name, column_name_list, sample_boundary
+            )
             LOGGER.debug("Choosing a SAMPLE query as table size is big")
         except NotImplementedError:
             LOGGER.warning(

--- a/poetry.lock
+++ b/poetry.lock
@@ -2936,7 +2936,7 @@ datahub = ["acryl-datahub", "great-expectations"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6,<3.9"
-content-hash = "0791e569f5b93da980a033f4f1152b5d2943dfd286c8c7f8532d546b2afce1d1"
+content-hash = "386eacc4c2710fccabcd4900e20367a790a829b2e338ef8ba90ed21fc2387c79"
 
 [metadata.files]
 acryl-datahub = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "piicatcher"
-version = "0.17.5"
+version = "0.18.0"
 description = "Find PII data in databases"
 authors = ["Tokern <info@tokern.io>"]
 license = "Apache 2.0"
@@ -35,6 +35,7 @@ tabulate = "^0.8.9"
 dataclasses = {version = ">=0.6", markers="python_version >= '3.6' and python_version < '3.7'"}
 great-expectations = {version = "^0.13.42", optional = true}
 acryl-datahub = {version = "^0.8.16", optional = true}
+tqdm = "^4.62.3"
 
 [tool.poetry.extras]
 datahub = ["acryl-datahub", "great-expectations"]

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -160,7 +160,9 @@ def test_deep_scan(load_data_and_pull):
     with catalog.managed_session:
         source = catalog.get_source_by_id(source_id)
         deep_scan(
-            catalog=catalog, generator=data_generator(catalog=catalog, source=source)
+            catalog=catalog,
+            work_generator=column_generator(catalog=catalog, source=source),
+            generator=data_generator(catalog=catalog, source=source),
         )
 
         schemata = catalog.search_schema(source_like=source.name, schema_like="%")


### PR DESCRIPTION
Support a progress bar using tqdm only for deep scans.
Add support for deep scans for AWS Athena.
In Postgres and Redshift a percentage of rows were processed instead of
a limited number of rows. Add a LIMIT clause for these databases.

Fix #159