### PR TITLE
Remote step to update Docker Hub description

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,9 +62,3 @@ jobs:
         context: docker
         push: true
         tags: tokern/piicatcher:latest tokern/piicatcher:${{ github.event.release.tag_name }}
-    - name: Docker Hub Description
-      uses: peter-evans/dockerhub-description@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-        repository: tokern/piicatcher


### PR DESCRIPTION
Have converted the Docker Hub tokern account into an organisation. The headless user account we use to publish images to Docker Hub requires 2FA, so using username/password no longer works. And the dockerhub-description action doesn't work with access tokens. So removing this step from the publish workflow for now.